### PR TITLE
provide another way installing linuxbrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Paste at a Terminal prompt:
 sudo apt-get install build-essential curl git python-setuptools ruby
 ```
 
+If you are Debian testing/sid or Ubuntu-devel user you can install only a single package
+```sh
+sudo apt install linuxbrew-wrapper
+```
+
 ### Fedora, CentOS or Red Hat
 
 ```sh


### PR DESCRIPTION
As said in `linuxbrew/install` 's PR 1, a `linuxbrew-wrapper` package containing the install scripts is provided for Debian testing+sid / Ubuntu devel users. Because of the Linuxbrew upstream update,
the content in the current wrapper package may be outdated but I'm working on the package update.

Please consider recommending this package for Debian testing/sid or Ubuntu-devel users.